### PR TITLE
Add O_TRUNC to OpenFile flags to prevent file corruption

### DIFF
--- a/commands/sync.go
+++ b/commands/sync.go
@@ -48,11 +48,7 @@ func runSync(cmd *cobra.Command, args []string) {
 
 func writeDestinations(destinations map[string]string) {
 	destinationsPath := filepath.Join(rootDir, destination.FileName)
-	if _, err := os.Stat(destinationsPath); os.IsNotExist(err) {
-		_, err = os.Create(destinationsPath)
-		check(err)
-	}
-	file, err := os.OpenFile(destinationsPath, os.O_WRONLY, 0644)
+	file, err := os.OpenFile(destinationsPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	check(err)
 	defer file.Close()
 	data, err := yaml.Marshal(destinations)
@@ -62,11 +58,7 @@ func writeDestinations(destinations map[string]string) {
 
 func writeMonitors(monitors map[string]monitor.Monitor) {
 	destinationsPath := filepath.Join(rootDir, "monitors.yaml")
-	if _, err := os.Stat(destinationsPath); os.IsNotExist(err) {
-		_, err = os.Create(destinationsPath)
-		check(err)
-	}
-	file, err := os.OpenFile(destinationsPath, os.O_WRONLY, 0644)
+	file, err := os.OpenFile(destinationsPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	check(err)
 	defer file.Close()
 	var monitorsList []monitor.Monitor


### PR DESCRIPTION
Hi, Thank you for publishing a useful tool. I found some issues for me. I'll make other Pull Requests later.

- O_TRUNC to prevent file corruption if new data is smaller than old one
- O_CREATE to create if file does not exist