### PR TITLE
Support Action Throttle

### DIFF
--- a/monitor/localOperations.go
+++ b/monitor/localOperations.go
@@ -7,7 +7,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
-	"gopkg.in/mihirsoni/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 //GetAllLocal Parse all local monitors under rootDir

--- a/monitor/models.go
+++ b/monitor/models.go
@@ -44,10 +44,12 @@ type Action struct {
 	DestinationID string `json:"destination_id,omitempty" yaml:"destinationId"`
 	// Why duplicated Subject and Message ? This is to simplify customer experience on writing new monitors.
 	// Taking input which is important default are being filled by CLI
-	Subject         string `json:"-"`
-	Message         string `json:"-"`
-	SubjectTemplate Script `json:"subject_template" yaml:"-"`
-	MessageTemplate Script `json:"message_template" yaml:"-"`
+	Subject         string    `json:"-"`
+	Message         string    `json:"-"`
+	SubjectTemplate Script    `json:"subject_template" yaml:"-"`
+	MessageTemplate Script    `json:"message_template" yaml:"-"`
+	ThrottleEnabled bool      `json:"throttle_enabled,omitempty" yaml:"throttleEnabled"`
+	Throttle        *Throttle `json:"throttle,omitempty"`
 }
 
 //Script Works for mustache and painless
@@ -59,6 +61,12 @@ type Script struct {
 //Condition define condition for the triggers
 type Condition struct {
 	Script Script `json:"script"`
+}
+
+// Throttle define throttling duration for the action
+type Throttle struct {
+	Value int    `json:"value"`
+	Unit  string `json:"unit"`
 }
 
 // Monitor Alert monitor object


### PR DESCRIPTION
This PR is very similar to #6, with one difference. To make `omitempty` work, I added a Throttle struct as a pointer.

## Enabled

```yaml
throttleEnabled: true
throttle:
  value: 10
  unit: MINUTES
```

convert to

```json
"throttle_enabled": true,
"throttle": {
  "value": 10,
  "unit": "MINUTES"
}
```

## Disabled

```yaml
throttleEnabled: false
throttle: null
```

convert to none.

## yaml version

I got a error below with `gopkg.in/mihirsoni/yaml.v2`.
So I changed to yaml.v3.

```
Unable to parse monitor correctly: json: unsupported type: map[interface {}]interface {}
```